### PR TITLE
ace-window-display-mode: parametrized face for ace-window-path display

### DIFF
--- a/ace-window.el
+++ b/ace-window.el
@@ -102,9 +102,14 @@ Use M-0 `ace-window' to toggle this value."
   '((t (:foreground "gray40")))
   "Face for whole window background during selection.")
 
-(defface aw-mode-line-face
+(defface aw-face-mode-line
   '((t (:foreground "black")))
   "Face used for displaying the ace window key in the mode-line.")
+
+(defcustom aw-mode-line-face
+  'aw-face-mode-line
+  "Face for modeline."
+  :type 'sexp)
 
 ;;* Implementation
 (defun aw-ignored-p (window)
@@ -456,7 +461,7 @@ The point is writable, i.e. it's not part of space after newline."
       leaf 'ace-window-path
       (propertize
        (apply #'string (reverse path))
-       'face 'aw-mode-line-face)))))
+       'face aw-mode-line-face)))))
 
 (provide 'ace-window)
 


### PR DESCRIPTION
Vanilla ace-window displays ace-window-path in its own predefined face. However, there maybe some people like me, who can barely see its contents as it is displayed with black foreground. So I introduced additional variable to make this customizable.