### PR TITLE
avy-jump.el: Make sure avi-move-line and avi-copy-line behave consistently.

### DIFF
--- a/avy-jump.el
+++ b/avy-jump.el
@@ -315,7 +315,8 @@ ARG lines can be used."
         (move-end-of-line arg)
         (kill-region start (point)))
       (insert
-       (current-kill 0)))))
+       (current-kill 0)
+       "\n"))))
 
 ;;;###autoload
 (defun avi-copy-region ()


### PR DESCRIPTION
Hi,

Thanks for creating this package! :)

Today I noticed that `avi-move-line` and `avi-copy-line` behave inconsistently w/r/t to whitespace:

`avi-copy-line` inserts a trailing newline, `avi-move-line` doesn't. Assuming that inserting a newline is the expected behavior, this pull request adds code to make sure that the two commands behave consistently.

