### PR TITLE
fix dependency of avy_jump

### DIFF
--- a/ace-window.el
+++ b/ace-window.el
@@ -60,7 +60,7 @@
 ;; deleted instead.
 
 ;;; Code:
-(require 'avy)
+(require 'avy-jump)
 (require 'ring)
 
 ;;* Customization


### PR DESCRIPTION
fix for https://github.com/abo-abo/ace-window/issues/49