### PR TITLE
Add 'visible option for aw-scope

### DIFF
--- a/ace-window.el
+++ b/ace-window.el
@@ -75,6 +75,7 @@
 (defcustom aw-scope 'global
   "The scope used by `ace-window'."
   :type '(choice
+          (const :tag "visible frames" visible)
           (const :tag "global" global)
           (const :tag "frame" frame)))
 
@@ -142,6 +143,8 @@ This will make `ace-window' act different from `other-window' for
             (string= "initial_terminal" (terminal-name f))
             (aw-ignored-p w))))
     (cl-case aw-scope
+      (visible
+       (cl-mapcan #'window-list (visible-frame-list)))
       (global
        (cl-mapcan #'window-list (frame-list)))
       (frame
@@ -278,6 +281,7 @@ Amend MODE-LINE to the mode line for the duration of the selection."
   (setq aw-action action)
   (let ((start-window (selected-window))
         (next-window-scope (cl-case aw-scope
+                             ('visible 'visible)
                              ('global 'visible)
                              ('frame 'frame)))
         (wnd-list (aw-window-list))
@@ -297,7 +301,8 @@ Amend MODE-LINE to the mode line for the duration of the selection."
                       (not aw-dispatch-always)
                       (not aw-ignore-current))
                  (let ((wnd (next-window nil nil next-window-scope)))
-                   (while (and (aw-ignored-p wnd)
+                   (while (and (or (not (memq wnd wnd-list))
+                                   (aw-ignored-p wnd))
                                (not (equal wnd start-window)))
                      (setq wnd (next-window wnd nil next-window-scope)))
                    wnd))


### PR DESCRIPTION
This works to allow switching only between frames in the
visible-frame-list. If you use i3, you can employ
https://github.com/vava/i3-emacs to advise visible-frame-list so that it
only contains frames which are actually on a visible workspace.