### PR TITLE
Fix missing leading characters

### DIFF
--- a/ace-window.el
+++ b/ace-window.el
@@ -156,6 +156,9 @@ This will make `ace-window' act different from `other-window' for
 (defvar aw-overlays-back nil
   "Hold overlays for when `aw-background' is t.")
 
+(defvar aw-window-cursors nil
+  "Hold list of (window point) pairs to restore original cursor positions.")
+
 (defvar ace-window-mode nil
   "Minor mode during the selection process.")
 
@@ -172,6 +175,10 @@ Modify them back eventually.")
   "Clean up mode line and overlays."
   ;; mode line
   (aw-set-mode-line nil)
+  ;; restore cursors
+  (dolist (wcpair aw-window-cursors)
+    (funcall #'set-window-point (car wcpair) (cdr wcpair)))
+  (setq aw-window-cursors nil)
   ;; background
   (mapc #'delete-overlay aw-overlays-back)
   (setq aw-overlays-back nil)
@@ -188,6 +195,8 @@ Modify them back eventually.")
 LEAF is (PT . WND)."
   (let ((wnd (cdr leaf)))
     (with-selected-window wnd
+      (push (cons wnd (window-point wnd)) aw-window-cursors)
+      (goto-char (window-start))
       (when (= 0 (buffer-size))
         (push (current-buffer) aw-empty-buffers-list)
         (let ((inhibit-read-only t))


### PR DESCRIPTION
Fixes #75

The problem this commit fixes comes from the fact that sometimes emacs
scrolls the window when the overlay applied. This can happen for example
if the aw-leading-char-face's height is increased to make it bigger and
the cursor is near the bottom of the window. Then emacs might scroll the
window to make sure the cursor stays visible.
The idea here is to temporarily move the cursor to the leading char's
position for the overlay and then restore it when we're done with the
overlay.

Change-Id: I3921c3d4e26a6d5df4a431c8bbf4f2f3b12cb382
