### PR TITLE
Fix frames order

### DIFF
--- a/ace-window.el
+++ b/ace-window.el
@@ -394,7 +394,7 @@ Windows are numbered top down, left to right."
         (e2 (window-edges wnd2)))
     (cond ((string< (frame-parameter f1 'window-id)
                     (frame-parameter f2 'window-id))
-           t)
+           nil)
           ((< (car e1) (car e2))
            t)
           ((> (car e1) (car e2))


### PR DESCRIPTION
Now the ordering of the frames in ace-window will match the one
exhibited by next-multiframe-window/previous-multiframe-window.

Change-Id: I10a6e4cca281cbe44c9c6806d1c67c28be7f2202