### PR TITLE
* ace-window.el (ace-maximize-window): Rename

### DIFF
--- a/ace-window.el
+++ b/ace-window.el
@@ -266,7 +266,7 @@ LEAF is (PT . WND)."
     (?c aw-split-window-fair " Ace - Split Fair Window")
     (?v aw-split-window-vert " Ace - Split Vert Window")
     (?b aw-split-window-horz " Ace - Split Horz Window")
-    (?i delete-other-windows " Ace - Maximize Window")
+    (?i delete-other-windows " Ace - Delete Other Windows")
     (?o delete-other-windows))
   "List of actions for `aw-dispatch-default'.")
 
@@ -359,11 +359,14 @@ Amend MODE-LINE to the mode line for the duration of the selection."
              #'aw-swap-window))
 
 ;;;###autoload
-(defun ace-maximize-window ()
-  "Ace maximize window."
+(defun ace-delete-other-windows ()
+  "Ace delete other windows."
   (interactive)
-  (aw-select " Ace - Maximize Window"
+  (aw-select " Ace - Delete Other Windows"
              #'delete-other-windows))
+
+(define-obsolete-function-alias
+  'ace-maximize-window 'ace-delete-other-windows "0.10.0")
 
 ;;;###autoload
 (defun ace-window (arg)


### PR DESCRIPTION
Make `ace-maximize-window` an obsolete alias of `ace-delete-other-windows` to remain consistent with the corresponding functions in `lisp/window.el`.

Copyright-paperwork-exempt: yes

Fixes #85