### PR TITLE
Help for dispatch actions

### DIFF
--- a/ace-window.el
+++ b/ace-window.el
@@ -260,28 +260,33 @@ LEAF is (PT . WND)."
   (force-mode-line-update))
 
 (defvar aw-dispatch-alist
-  '((?x aw-delete-window " Ace - Delete Window")
-    (?m aw-swap-window " Ace - Swap Window")
-    (?M aw-move-window " Ace - Move Window")
-    (?j aw-switch-buffer-in-window " Ace - Select Buffer")
+  '((?x aw-delete-window "Delete Window")
+    (?m aw-swap-window "Swap Window")
+    (?M aw-move-window "Move Window")
+    (?j aw-switch-buffer-in-window "Select Buffer")
     (?n aw-flip-window)
-    (?c aw-split-window-fair " Ace - Split Fair Window")
-    (?v aw-split-window-vert " Ace - Split Vert Window")
-    (?b aw-split-window-horz " Ace - Split Horz Window")
-    (?i delete-other-windows " Ace - Delete Other Windows")
+    (?c aw-split-window-fair "Split Fair Window")
+    (?v aw-split-window-vert "Split Vert Window")
+    (?b aw-split-window-horz "Split Horz Window")
+    (?i delete-other-windows "Delete Other Windows")
     (?o delete-other-windows))
   "List of actions for `aw-dispatch-default'.")
 
+(defun aw--dispatch-action (char)
+  "Return item from `aw-dispatch-alist' matching CHAR."
+  (assoc char aw-dispatch-alist))
+
 (defun aw-dispatch-default (char)
   "Perform an action depending on CHAR."
-  (let ((val (cdr (assoc char aw-dispatch-alist))))
-    (if val
-        (if (and (car val) (cadr val))
-            (prog1 (setq aw-action (car val))
-              (aw-set-mode-line (cadr val)))
-          (funcall (car val))
-          (throw 'done 'exit))
-      (avy-handler-default char))))
+  (let ((action (aw--dispatch-action char)))
+    (cl-destructuring-bind (_key fn &optional description) (aw--dispatch-action char)
+      (if action
+          (if (and fn description)
+              (prog1 (setq aw-action fn)
+                (aw-set-mode-line (format " Ace - %s" description)))
+            (funcall fn)
+            (throw 'done 'exit))
+        (avy-handler-default char)))))
 
 (defun aw-select (mode-line &optional action)
   "Return a selected other window.

--- a/ace-window.el
+++ b/ace-window.el
@@ -269,7 +269,8 @@ LEAF is (PT . WND)."
     (?v aw-split-window-vert "Split Vert Window")
     (?b aw-split-window-horz "Split Horz Window")
     (?i delete-other-windows "Delete Other Windows")
-    (?o delete-other-windows))
+    (?o delete-other-windows)
+    (?? aw-show-dispatch-help))
   "List of actions for `aw-dispatch-default'.")
 
 (defun aw--dispatch-action (char)
@@ -459,6 +460,16 @@ Windows are numbered top down, left to right."
   "Switch to the window you were previously in."
   (interactive)
   (aw-switch-to-window (aw--pop-window)))
+
+(defun aw-show-dispatch-help ()
+  "Display action shortucts in echo area."
+  (interactive)
+  (message "%s" (mapconcat
+                 (lambda (action)
+                   (cl-destructuring-bind (key fn &optional description) action
+                     (format "%s: %s" (char-to-string key) (or description fn))))
+                 aw-dispatch-alist
+                 "\n")))
 
 (defun aw-delete-window (window)
   "Delete window WINDOW."

--- a/ace-window.el
+++ b/ace-window.el
@@ -299,8 +299,8 @@ Amend MODE-LINE to the mode line for the duration of the selection."
                  (when aw-dispatch-always
                    (setq aw-action
                          (unwind-protect
-                              (catch 'done
-                                (funcall aw-dispatch-function (read-char)))
+                             (catch 'done
+                               (funcall aw-dispatch-function (read-char)))
                            (aw--done)))
                    (when (eq aw-action 'exit)
                      (setq aw-action nil)))
@@ -324,15 +324,15 @@ Amend MODE-LINE to the mode line for the duration of the selection."
                    ;; turn off helm transient map
                    (remove-hook 'post-command-hook 'helm--maybe-update-keymap)
                    (unwind-protect
-                        (let* ((avy-handler-function aw-dispatch-function)
-                               (avy-translate-char-function #'identity)
-                               (res (avy-read (avy-tree candidate-list aw-keys)
-                                              #'aw--lead-overlay
-                                              #'avy--remove-leading-chars)))
-                          (if (eq res 'exit)
-                              (setq aw-action nil)
-                            (or (cdr res)
-                                start-window)))
+                       (let* ((avy-handler-function aw-dispatch-function)
+                              (avy-translate-char-function #'identity)
+                              (res (avy-read (avy-tree candidate-list aw-keys)
+                                             #'aw--lead-overlay
+                                             #'avy--remove-leading-chars)))
+                         (if (eq res 'exit)
+                             (setq aw-action nil)
+                           (or (cdr res)
+                               start-window)))
                      (aw--done))))))
     (if aw-action
         (funcall aw-action window)


### PR DESCRIPTION
When pressing `?`, a list of all actions is displayed in the echo area.

![screenshot from 2017-11-08 11-25-17](https://user-images.githubusercontent.com/217543/32544000-8b3d9644-c477-11e7-928e-165b290a0ebc.png)

*Limitation:* When pressing `?`, the actions are correctly displayed, but ace-window exits. It could be nice if ace-window would stay around, waiting for the next char.