### PR TITLE
Switch buffer other window

### DIFF
--- a/ace-window.el
+++ b/ace-window.el
@@ -502,9 +502,15 @@ Windows are numbered top down, left to right."
 (defun aw-switch-buffer-in-window (window)
   "Select buffer in WINDOW."
   (aw-switch-to-window window)
-  (if (bound-and-true-p ivy-mode)
-      (ivy-switch-buffer)
-    (call-interactively 'switch-to-buffer)))
+  (aw--switch-buffer))
+
+(defun aw--switch-buffer ()
+  (cond ((bound-and-true-p ivy-mode)
+         (ivy-switch-buffer))
+        ((bound-and-true-p ido-mode)
+         (ido-switch-buffer))
+        (t
+         (call-interactively 'switch-to-buffer))))
 
 (defcustom aw-swap-invert nil
   "When non-nil, the other of the two swapped windows gets the point."

--- a/ace-window.el
+++ b/ace-window.el
@@ -273,6 +273,7 @@ LEAF is (PT . WND)."
     (?M aw-move-window "Move Window")
     (?j aw-switch-buffer-in-window "Select Buffer")
     (?n aw-flip-window)
+    (?u aw-switch-buffer-other-window "Switch Buffer Other Window")
     (?c aw-split-window-fair "Split Fair Window")
     (?v aw-split-window-vert "Split Vert Window")
     (?b aw-split-window-horz "Split Horz Window")
@@ -569,6 +570,12 @@ Modify `aw-fair-aspect-ratio' to tweak behavior."
     (if (< (* h aw-fair-aspect-ratio) w)
         (aw-split-window-horz window)
       (aw-split-window-vert window))))
+
+(defun aw-switch-buffer-other-window (window)
+  "Switch buffer in WINDOW without selecting WINDOW."
+  (aw-switch-to-window window)
+  (aw--switch-buffer)
+  (aw-flip-window))
 
 (defun aw-offset (window)
   "Return point in WINDOW that's closest to top left corner.


### PR DESCRIPTION
This PR adds two functions:

1. `aw-switch-buffer-other-window`, which switches into another window, changes the buffer, and then switches back; and

2. `aw--switch-buffer`, a selector for various buffer-switching functions.