### PR TITLE
(Issue #110 implementation): 'z' window identifier creates a new frame as a target

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 
 ## What and why
 
-I'm sure you're aware of `other-window` command. While it's great for
-two windows, it quickly loses its value when there are more windows:
-you need to call it many times, and since it's not easily predictable,
+I'm sure you're aware of the `other-window` command. While it's great
+for two windows, it quickly loses its value when there are more windows.
+You need to call it many times, and since it's not easily predictable,
 you have to check each time if you're in the window that you wanted.
 
 Another approach is to use `windmove-left`, `windmove-up`, etc.  These
-are fast and predictable. Their disadvantage is that they need 4 key
+are fast and predictable.  Their disadvantage is that they need 4 key
 bindings.  The default ones are shift+arrows, which are hard to reach.
 
 This package aims to take the speed and predictability of `windmove`
@@ -19,24 +19,33 @@ and pack it into a single key binding, similar to `other-window`.
 ## Setup
 
 Just assign `ace-window` to a short key binding, as switching windows
-is a common task. I suggest <kbd>M-p</kbd>, as it's short and not
+is a common task.  I suggest <kbd>M-p</kbd>, as it's short and not
 bound in the default Emacs.
 
 ## Usage
 
 When there are two windows, `ace-window` will call `other-window`.  If
-there are more, each window will have its first character highlighted.
-Pressing that character will switch to that window.  Note that, unlike
-`ace-jump-mode`, the point position will not be changed: it's the same
-behavior as that of `other-window`.
+there are more, each window will have the first character of its window
+identifier highlighted at the upper left of the window.  Pressing that
+character will either switch to that window or filter to the next
+character needed to select a specific window.  Note that, unlike
+`ace-jump-mode`, the position of point will not be changed, i.e. the
+same behavior as that of `other-window`.
 
-The windows are ordered top-down, left-to-right. This means that if
-you remember your window layouts, you can switch windows without even
+A special character defined by `aw-make-frame-char` (default = `z`)
+means create a new frame and use its window as the target.  The new
+frame's location is set relative to the prior selected frame's location
+and given by `aw-frame-offset`.  The new frame's size is given by
+`aw-frame-size`.  See their documentation strings for more information.
+
+The windows are ordered top-down, left-to-right. This means that if you
+remember your window layouts, you can switch windows without even
 looking at the leading char.  For instance, the top left window will
-always be `1`.
+always be `1` (or `a` if you use letters for window characters).
 
 `ace-window` works across multiple frames, as you can see from the
 [in-action gif](http://oremacs.com/download/ace-window.gif).
+
 
 ## Swap and delete window
 
@@ -49,27 +58,30 @@ always be `1`.
 You can also start by calling `ace-window` and then decide to switch the action to `delete` or `swap` etc.  By default the bindings are:
 
 - <kbd>x</kbd> - delete window
-- <kbd>m</kbd> - swap (move) window
+- <kbd>m</kbd> - swap windows
+- <kbd>M</kbd> - move window
+- <kbd>j</kbd> - select buffer
+- <kbd>n</kbd> - select the previous window
+- <kbd>u</kbd> - select buffer in the other window
 - <kbd>c</kbd> - split window fairly, either vertically or horizontally
 - <kbd>v</kbd> - split window vertically
 - <kbd>b</kbd> - split window horizontally
-- <kbd>n</kbd> - select the previous window
-- <kbd>i</kbd> - maximize window (select which window)
 - <kbd>o</kbd> - maximize current window
+- <kbd>?</kbd> - show these command bindings
 
-In order for it to work, these keys *must not* be in
-`aw-keys`. Additionally, if you want these keys to work with less than
-three windows, you need to have `aw-dispatch-always` set to `t`.
+For proper operation, these keys *must not* be in `aw-keys`.  Additionally,
+if you want these keys to work with fewer than three windows, you need to
+have `aw-dispatch-always` set to `t`.
 
 ## Customization
 Aside from binding `ace-window`:
 
     (global-set-key (kbd "M-p") 'ace-window)
 
-maybe you'd like the following customizations:
+the following customizations are available:
 
 ### `aw-keys`
-`aw-keys` - the sequence of leading characters for each window:
+`aw-keys` - the list of initial characters used in window identifiers:
 
     (setq aw-keys '(?a ?s ?d ?f ?g ?h ?j ?k ?l))
 
@@ -78,14 +90,14 @@ above, the keys are on the home row.
 
 ### `aw-scope`
 The default one is `global`, which means that `ace-window` will work
-across frames. If you set this to `frame`, `ace-window` will offer you
-the windows only on current frame.
+across frames.  If you set this to `frame`, `ace-window` will offer you
+only the windows of the current frame.
 
 ### `aw-background`
 
 By default, `ace-window` temporarily sets a gray background and
 removes color from available windows in order to make the
-window-switching characters more visible. This is the behavior
+window-switching characters more visible.  This is the behavior
 inherited from `ace-jump-mode`.
 
 This behavior might not be necessary, as you already know the locations
@@ -98,27 +110,29 @@ So you can turn off the gray background with:
 
 When non-nil, `ace-window` will issue a `read-char` even for one window.
 This will make `ace-window` act differently from `other-window` for one
-or two windows. This is useful to change the action midway
-and execute other action other than the *jump* default.
-By default is set to `nil`
+or two windows.  This is useful to change the action midway and execute
+an action other than the default *jump* action.
+By default, this is set to `nil`.
 
 ### `aw-dispatch-alist`
 
-This is the list of actions that you can trigger from `ace-window` other than the
-*jump* default.
-By default is:
+This is the list of actions you can trigger from `ace-window` other than the
+*jump* default.  By default it is:
 
-    (defvar aw-dispatch-alist
-    '((?x aw-delete-window " Ace - Delete Window")
-        (?m aw-swap-window " Ace - Swap Window")
-        (?n aw-flip-window)
-        (?c aw-split-window-fair " Ace - Split Fair Window")
-        (?v aw-split-window-vert " Ace - Split Vert Window")
-        (?b aw-split-window-horz " Ace - Split Horz Window")
-        (?i delete-other-windows " Ace - Maximize Window")
-        (?o delete-other-windows))
-    "List of actions for `aw-dispatch-default'.")
+	(defvar aw-dispatch-alist
+	  '((?x aw-delete-window "Delete Window")
+		(?m aw-swap-window "Swap Windows")
+		(?M aw-move-window "Move Window")
+		(?j aw-switch-buffer-in-window "Select Buffer")
+		(?n aw-flip-window)
+		(?u aw-switch-buffer-other-window "Switch Buffer Other Window")
+		(?c aw-split-window-fair "Split Fair Window")
+		(?v aw-split-window-vert "Split Vert Window")
+		(?b aw-split-window-horz "Split Horz Window")
+		(?o delete-other-windows "Delete Other Windows")
+		(?? aw-show-dispatch-help))
+	  "List of actions for `aw-dispatch-default'.")
 
-If the pair key-action is followed by a string, then `ace-window` will be
-invoked again to be able to select on which window you want to select the
-action. Otherwise the current window is selected.
+When using ace-window, if the action character is followed by a string,
+then `ace-window` will be invoked again to select the target window for
+the action.  Otherwise, the current window is selected.

--- a/ace-window.el
+++ b/ace-window.el
@@ -287,7 +287,7 @@ LEAF is (PT . WND)."
 
 (defvar aw-dispatch-alist
   '((?x aw-delete-window "Delete Window")
-    (?m aw-swap-window "Swap Window")
+    (?m aw-swap-window "Swap Windows")
     (?M aw-move-window "Move Window")
     (?j aw-switch-buffer-in-window "Select Buffer")
     (?n aw-flip-window)
@@ -295,8 +295,7 @@ LEAF is (PT . WND)."
     (?c aw-split-window-fair "Split Fair Window")
     (?v aw-split-window-vert "Split Vert Window")
     (?b aw-split-window-horz "Split Horz Window")
-    (?i delete-other-windows "Delete Other Windows")
-    (?o delete-other-windows)
+    (?o delete-other-windows "Delete Other Windows")
     (?? aw-show-dispatch-help))
   "List of actions for `aw-dispatch-default'.")
 


### PR DESCRIPTION
This allows specifying a new frame as the window target.
A special character defined by `aw-make-frame-char` (default = `z`)
means create a new frame and use its window as the target.  The new
frame's location is set relative to the prior selected frame's location
and given by `aw-frame-offset`.  The new frame's size is given by
`aw-frame-size`.  See their documentation strings for more information.

Full functionality is implemented in the first commit.  The second commit
removes the 'i' command binding (duplicate of 'o') for Hyperbole compatibility
and updates the README.md to the latest set of commands.