### PR TITLE
Do not ignore window-parameters

### DIFF
--- a/ace-window.el
+++ b/ace-window.el
@@ -159,7 +159,13 @@ Its value is a (width . height) pair in pixels or nil for the default frame size
            (member (buffer-name (window-buffer window))
                    aw-ignored-buffers))
       (and aw-ignore-current
-           (equal window (selected-window)))))
+           (equal window (selected-window)))
+      (unless ignore-window-parameters
+        (cl-case this-command
+          (ace-select-window (window-parameter window 'no-other-window))
+          (ace-delete-window (window-parameter window 'no-delete-other-windows))
+          (ace-delete-other-windows (window-parameter
+                                     window 'no-delete-other-windows))))))
 
 (defun aw-window-list ()
   "Return the list of interesting windows."


### PR DESCRIPTION
This is a PR for issue  #93.  By merging this, `ace-select-window` (resp. `ace-delete-window`) behaves like `other-window` (resp. `delete-other-window`). This feature can be disabled by setting `ignore-window-parameters` to non-`nil`.