### PR TITLE
Fix frame-parameter being nil sometimes

### DIFF
--- a/ace-window.el
+++ b/ace-window.el
@@ -580,13 +580,16 @@ window."
   "Return true if WND1 is less than WND2.
 This is determined by their respective window coordinates.
 Windows are numbered top down, left to right."
-  (let ((f1 (window-frame wnd1))
-        (f2 (window-frame wnd2))
-        (e1 (window-edges wnd1))
-        (e2 (window-edges wnd2)))
-    (cond ((< (car (frame-position f1)) (car (frame-position f2)))
+  (let* ((f1 (window-frame wnd1))
+	 (f2 (window-frame wnd2))
+	 (e1 (window-edges wnd1))
+	 (e2 (window-edges wnd2))
+	 (p1 (frame-position f1))
+	 (p2 (frame-position f2))
+	 (nl (or (null (car p1)) (null (car p2)))))
+    (cond ((and (not nl) (< (car p1) (car p2)))
            (not aw-reverse-frame-list))
-          ((> (car (frame-position f1)) (car (frame-position f2)))
+          ((and (not nl) (> (car p1) (car p2)))
            aw-reverse-frame-list)
           ((< (car e1) (car e2))
            t)


### PR DESCRIPTION
Hello,

I get an error that looks a lot like Issue #138 when using Emacs-24.5.1. It occurs when installing ace-window from melpa or building from the latest github commit. 

```
Debugger entered--Lisp error: (wrong-type-argument number-or-marker-p nil)                                    
  aw-window<(#<window 4 on *Backtrace*> #<window 1 on *scratch*>)                                             
  sort((#<window 1 on *scratch*>) aw-window<)                                                                 
  aw-window-list()                                                                                            
  aw-select(" Ace - Window" aw-switch-to-window)                                                              
  ace-select-window()                                                                                         
  ace-window(1)                                                                                               
  call-interactively(ace-window record nil)                                                                   
  command-execute(ace-window record)                                                                          
  execute-extended-command(nil "ace-window")                                                                  
  call-interactively(execute-extended-command nil nil)                                                        
  command-execute(execute-extended-command)  
```

It appears that `(frame-parameter frame 'left)` returns nil, thus `(frame-position f1)` is `'(nil)`, and line 587 attempts to evaluate `(< nil nil)`, giving rise to the error.

ace-window works for me after making the change in this pull request.

https://github.com/abo-abo/ace-window/blob/5b88de026cea5fc57e62bb490034392815be5f0f/ace-window.el#L569-L572

https://github.com/abo-abo/ace-window/blob/5b88de026cea5fc57e62bb490034392815be5f0f/ace-window.el#L587-L589

