### PR TITLE
Update the name of the LV buffer

### DIFF
--- a/ace-window.el
+++ b/ace-window.el
@@ -96,7 +96,7 @@ For example, to make SPC do the same as ?a, use
   "When non-nil, also display `ace-window-mode' string in the minibuffer when ace-window is active."
   :type 'boolean)
 
-(defcustom aw-ignored-buffers '("*Calc Trail*" "*LV*")
+(defcustom aw-ignored-buffers '("*Calc Trail*" " *LV*")
   "List of buffers and major-modes to ignore when choosing a window from the window list.
 Active only when `aw-ignore-on' is non-nil.  Windows displaying these
 buffers can still be chosen by typing their specific labels."


### PR DESCRIPTION
The name of an LV buffer has been changed to `" *LV"` for a while.

By the way, I am a bit confused on the docstring of this variable:
> Windows displaying these buffers can still be chosen by typing their specific labels.

Does that mean there is a way to switch to an ignored window other than `M-0` `ace-window`?

Thanks!