### PR TITLE
ace-window.el (aw-ignored-p): Only call frame-parent if defined

### DIFF
--- a/ace-window.el
+++ b/ace-window.el
@@ -217,7 +217,7 @@ or
                      aw-ignored-buffers)
                (member (buffer-name (window-buffer window)) aw-ignored-buffers)))
       ;; ignore child frames
-      (frame-parent (window-frame window))
+      (if (fboundp 'frame-parent) (frame-parent (window-frame window)))
       ;; Ignore selected window if `aw-ignore-current' is non-nil.
       (and aw-ignore-current
            (equal window (selected-window)))


### PR DESCRIPTION
Fixes crash on Emacs-24.5

```
Debugger entered--Lisp error: (void-function frame-parent)                                                                                                               
  frame-parent(#<frame F1 0xbe51e8>)                                                                                                                                     
  aw-ignored-p(#<window 1 on *scratch*>)                                                                                                                                 
  #[257 "\300^A!\301^A!\205\f^@\302^A!?\206^[^@\303^A!\304\230\206^[^@\305^B!\207" [window-frame frame-live-p frame-visible-p terminal-name "initial_terminal" aw-ignore$
  cl-remove(nil (#<window 1 on *scratch*> #<window 4 on *scratch*>) :if #[257 "\300^A!\301^A!\205\f^@\302^A!?\206^[^@\303^A!\304\230\206^[^@\305^B!\207" [window-frame f$
  apply(cl-remove nil (#<window 1 on *scratch*> #<window 4 on *scratch*>) :if #[257 "\300^A!\301^A!\205\f^@\302^A!?\206^[^@\303^A!\304\230\206^[^@\305^B!\207" [window-f$
  cl-remove-if(#[257 "\300^A!\301^A!\205\f^@\302^A!?\206^[^@\303^A!\304\230\206^[^@\305^B!\207" [window-frame frame-live-p frame-visible-p terminal-name "initial_termin$
  aw-window-list()                                                                                                                                                       
  aw-select(" Ace - Window" aw-switch-to-window)                                                                                                                         
  ace-select-window()                                                                                                                                                    
  ace-window(1)                                                                                                                                                          
  call-interactively(ace-window nil nil)                                                                                                                                 
  command-execute(ace-window)
```