### PR TITLE
Fix aw-switch-buffer-other-window bug

### DIFF
--- a/ace-window.el
+++ b/ace-window.el
@@ -750,10 +750,11 @@ Modify `aw-fair-aspect-ratio' to tweak behavior."
       (aw-split-window-vert window))))
 
 (defun aw-switch-buffer-other-window (window)
-  "Switch buffer in WINDOW without selecting WINDOW."
+  "Switch buffer in WINDOW."
   (aw-switch-to-window window)
-  (aw--switch-buffer)
-  (aw-flip-window))
+  (unwind-protect
+      (aw--switch-buffer)
+    (aw-flip-window)))
 
 (defun aw--face-rel-height ()
   (let ((h (face-attribute 'aw-leading-char-face :height)))


### PR DESCRIPTION
When aw-switch-buffer-other-window is executed, it switches to the
selected window, changes the buffer, and then switches back. If the
buffer-switching function is canceled, the window won't get switched
back. Using unwind-protect ensures that the function ends with the
starting window selected.