### PR TITLE
Fix window highlight in hollow cursor

### DIFF
--- a/ace-window.el
+++ b/ace-window.el
@@ -493,7 +493,8 @@ Amend MODE-LINE to the mode line for the duration of the selection."
                  (let ((candidate-list
                         (mapcar (lambda (wnd)
                                   (cons (aw-offset wnd) wnd))
-                                wnd-list)))
+                                wnd-list))
+                       (cursor-in-non-selected-windows nil))
                    (aw--make-backgrounds wnd-list)
                    (aw-set-mode-line mode-line)
                    ;; turn off helm transient map


### PR DESCRIPTION
When the cursor in non-selected windows becomes hollow, and the point is in the
same position as the window label, the label becomes invisible as it is rendered
with the background color of the cursor face.

Setting `cursor-in-non-selected-windows` to `nil` during selection, cursors in
non-selected windows are hidden completely. Hence the window label is always
visible.