### PR TITLE
Use call-interactively if the callee function is a command

### DIFF
--- a/ace-window.el
+++ b/ace-window.el
@@ -489,7 +489,9 @@ The new frame is set to the same size as the previous frame, offset by
                  (if (and fn description)
                      (prog1 (setq aw-action fn)
                        (aw-set-mode-line (format " Ace - %s" description)))
-                   (funcall fn)
+                   (if (commandp fn)
+                       (call-interactively fn)
+                     (funcall fn))
                    (throw 'done 'exit)))
              (aw-clean-up-avy-current-path)
              ;; Prevent any char from triggering an avy dispatch command.


### PR DESCRIPTION
I added a command to `aw-dispatch-alist`, but it didn't work because it is a function which requires arguments. Apparently, ace-window uses `funcall` to call a function in `aw-dispatch-alist`, but in my opinion, it should use `funcall-interactively` whenever the function is a command.