### PR TITLE
separate minibuffer face

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,3 +166,10 @@ When t, `ace-window` will ignore buffers and major-modes in
 ### `aw-ignore-current`
 
 When t, `ace-window` will ignore `selected-window'.
+
+### `aw-minibuffer-separate-face`
+
+When t, `ace-window` will use a separate face
+(`aw-minibuffer-leading-char-face`) for overlays in the minibuffer.
+This is useful if you want to use a huge font size for overlays which
+doesn't fit in the minibuffer.

--- a/ace-window.el
+++ b/ace-window.el
@@ -96,6 +96,10 @@ For example, to make SPC do the same as ?a, use
   "When non-nil, also display `ace-window-mode' string in the minibuffer when ace-window is active."
   :type 'boolean)
 
+(defcustom aw-minibuffer-separate-face nil
+  "When non-nil, use different face for minibuffer."
+  :type 'boolean)
+
 (defcustom aw-ignored-buffers '("*Calc Trail*" " *LV*")
   "List of buffers and major-modes to ignore when choosing a window from the window list.
 Active only when `aw-ignore-on' is non-nil."
@@ -198,6 +202,13 @@ or
     (((background light)) (:foreground "gray0"))
     (t (:foreground "gray100" :underline nil)))
   "Face for each window's leading char.")
+
+(defface aw-minibuffer-leading-char-face
+  '((((class color)) (:foreground "red"))
+    (((background dark)) (:foreground "gray100"))
+    (((background light)) (:foreground "gray0"))
+    (t (:foreground "gray100" :underline nil)))
+  "Face for minibuffer leading char.")
 
 (defface aw-background-face
   '((t (:foreground "gray40")))
@@ -396,7 +407,10 @@ LEAF is (PT . WND)."
             (goto-char (+ pt 1))
             (push (cons wnd old-pt) aw--windows-points)))
         (overlay-put ol 'display (aw--overlay-str wnd pt path))
-        (overlay-put ol 'face 'aw-leading-char-face)
+        (if (and aw-minibuffer-separate-face
+                 (window-minibuffer-p wnd))
+            (overlay-put ol 'face 'aw-minibuffer-leading-char-face)
+          (overlay-put ol 'face 'aw-leading-char-face))
         (overlay-put ol 'window wnd)
         (push ol avy--overlays-lead)))))
 


### PR DESCRIPTION
i use ace-window in a setup with many monitors and many separate frames. as a result, i found it useful to modify `aw-leading-char-face` so it was huge and easy to see. the problem was that if i ended up switching between windows while using the minibuffer, i would try to switch back to it, but be unable because i couldn't see the letter i was supposed to press to switch to it. and with so many possibilities, working out the letter it might be was too much trouble.

so instead, i define a separate face, which the user can optionally set to use for minibuffers. i can leave this one the normal size, and the problem goes away.