### PR TITLE
Separate minibuffer face variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,3 +166,10 @@ When t, `ace-window` will ignore buffers and major-modes in
 ### `aw-ignore-current`
 
 When t, `ace-window` will ignore `selected-window'.
+
+### `aw-minibuffer-separate-face`
+
+When t, `ace-window` will use a separate face
+(`aw-minibuffer-leading-char-face`) for overlays in the minibuffer.
+This is useful if you want to use a huge font size for overlays which
+doesn't fit in the minibuffer.

--- a/README.md
+++ b/README.md
@@ -169,7 +169,8 @@ When t, `ace-window` will ignore `selected-window'.
 
 ### `aw-minibuffer-separate-face`
 
-When t, `ace-window` will use a separate face
-(`aw-minibuffer-leading-char-face`) for overlays in the minibuffer.
-This is useful if you want to use a huge font size for overlays which
-doesn't fit in the minibuffer.
+The face to use for overlays in minibuffer windows. Defaults to the
+same face as regular windows (`aw-leading-char-face`). You can also
+set it to `'aw-minibuffer-leading-char-face` or any other face you
+like. This is useful if you want to use a huge font size for overlays
+which doesn't fit in the minibuffer.

--- a/ace-window.el
+++ b/ace-window.el
@@ -96,9 +96,9 @@ For example, to make SPC do the same as ?a, use
   "When non-nil, also display `ace-window-mode' string in the minibuffer when ace-window is active."
   :type 'boolean)
 
-(defcustom aw-minibuffer-separate-face nil
-  "When non-nil, use different face for minibuffer."
-  :type 'boolean)
+(defcustom aw-minibuffer-separate-face 'aw-leading-char-face
+  "Face for minibuffer overlays."
+  :type 'face)
 
 (defcustom aw-ignored-buffers '("*Calc Trail*" " *LV*")
   "List of buffers and major-modes to ignore when choosing a window from the window list.
@@ -407,9 +407,8 @@ LEAF is (PT . WND)."
             (goto-char (+ pt 1))
             (push (cons wnd old-pt) aw--windows-points)))
         (overlay-put ol 'display (aw--overlay-str wnd pt path))
-        (if (and aw-minibuffer-separate-face
-                 (window-minibuffer-p wnd))
-            (overlay-put ol 'face 'aw-minibuffer-leading-char-face)
+        (if (window-minibuffer-p wnd)
+            (overlay-put ol 'face aw-minibuffer-separate-face)
           (overlay-put ol 'face 'aw-leading-char-face))
         (overlay-put ol 'window wnd)
         (push ol avy--overlays-lead)))))

--- a/ace-window.el
+++ b/ace-window.el
@@ -96,6 +96,10 @@ For example, to make SPC do the same as ?a, use
   "When non-nil, also display `ace-window-mode' string in the minibuffer when ace-window is active."
   :type 'boolean)
 
+(defcustom aw-minibuffer-separate-face nil
+  "When non-nil, use different face for minibuffer."
+  :type 'boolean)
+
 (defcustom aw-ignored-buffers '("*Calc Trail*" " *LV*")
   "List of buffers and major-modes to ignore when choosing a window from the window list.
 Active only when `aw-ignore-on' is non-nil."
@@ -198,6 +202,13 @@ or
     (((background light)) (:foreground "gray0"))
     (t (:foreground "gray100" :underline nil)))
   "Face for each window's leading char.")
+
+(defface aw-minibuffer-leading-char-face
+  '((((class color)) (:foreground "red"))
+    (((background dark)) (:foreground "gray100"))
+    (((background light)) (:foreground "gray0"))
+    (t (:foreground "gray100" :underline nil)))
+  "Face for minibuffer leading char.")
 
 (defface aw-background-face
   '((t (:foreground "gray40")))
@@ -396,7 +407,10 @@ LEAF is (PT . WND)."
             (goto-char (+ pt 1))
             (push (cons wnd old-pt) aw--windows-points)))
         (overlay-put ol 'display (aw--overlay-str wnd pt path))
-        (overlay-put ol 'face 'aw-leading-char-face)
+        (if (and aw-minibuffer-separate-face
+                 (window-minibuffer-p wnd))
+            (overlay-put ol 'face 'aw-minibuffer-leading-char-face)
+          (overlay-put ol 'face 'aw-leading-char-face))
         (overlay-put ol 'window wnd)
         (push ol avy--overlays-lead)))))
 


### PR DESCRIPTION
Per request in #180, did this differently. I don't like this version as much because:

- the reasons i mentioned in #180.

- the documentation is now less straightforward.

- i'm not even sure i'm doing the `defcustom` form correctly. is `:type 'face` the right custom widget? It shows a preview, but you just edit the value as text rather than getting some kind of select-from-available-faces ui (not that I ever use customize myself, but apparently people do).

But it works the same as the other version.