### PR TITLE
Add ace-window function for display-buffer

### DIFF
--- a/ace-window.el
+++ b/ace-window.el
@@ -613,6 +613,26 @@ Amend MODE-LINE to the mode line for the duration of the selection."
   (aw-select " Ace - Delete Other Windows"
              #'delete-other-windows))
 
+;;;###autoload
+(defun ace-display-buffer (buffer alist)
+  "Ace display buffer.
+Can be added to `display-buffer-alist' and its relatives to
+select the window chosen by `display-buffer' and
+`pop-to-buffer'. Recognizes the action alist entries for
+'inhibit-same-window and 'reusable-frames (see the documentation
+of `display-buffer'). If there is only 1 window, returns nil,
+thus falling back to the next buffer display action."
+  (let ((aw-ignore-current (cdr (assq 'inhibit-same-window alist)))
+        (aw-scope (pcase (cdr (assq 'reusable-frames alist))
+                    ((pred not) 'frame)
+                    ('visible 'visible)
+                    ((or 0 (pred (eql t))) 'global)
+                    (_ nil))))
+    (unless (or (<= (length (aw-window-list)) 1)
+                (not aw-scope))
+      (window--display-buffer
+       buffer (aw-select "Ace - Display Buffer") 'reuse))))
+
 (declare-function transpose-frame "ext:transpose-frame")
 (defun aw-transpose-frame (w)
   "Select any window on frame and `tranpose-frame'."


### PR DESCRIPTION
I wrote a small function to use ace-window with the [display-buffer](https://www.gnu.org/software/emacs/manual/html_node/elisp/Choosing-Window.html#Choosing-Window) framework for choosing windows to display buffers in. I was wondering if you'd be interested in this contribution.

My motivation was that, when I have many windows open, `display-buffer` and `pop-to-buffer` will  open the buffer in some other window than the one I want. For example, this happens when calling `*Help*` functions (like `describe-function`) and following their links to elisp source files.

See this [reddit post](https://www.reddit.com/r/emacs/comments/ehv6vz/better_popup_buffers_with_acewindow/) for a screenshot of `ace-display-buffer` in action.

The function can be used by adding it to `display-buffer-alist` and its relatives. Here's my config where I use `ace-display-buffer` as my default `display-buffer` action, with some tweaks to accommodate helm, magit, and ESS:
```
(setq display-buffer-base-action '((display-buffer-reuse-window
                                    ace-display-buffer))
      display-buffer-alist '(("\\*help\\[R" (display-buffer-reuse-mode-window
                                             ace-display-buffer))
                             ("\\*helm"
                              ;; see also: `helm-split-window-default-fn'
                              (display-buffer-pop-up-window))
                             ("magit-diff:" (ace-display-buffer)
                              (inhibit-same-window . t))))
```



I've already assigned my copyright for Emacs to the FSF and can send you my papers if you want, or you can also verify this by looking up my name ("Jack Kamm") in the list of [copyrighted org-mode contributors](https://orgmode.org/worg/org-contribute.html).