### PR TITLE
Provide ace-window-posframe-mode

### DIFF
--- a/ace-window-posframe.el
+++ b/ace-window-posframe.el
@@ -1,0 +1,37 @@
+(defvar aw--posframe-frames '())
+
+(defun aw--lead-overlay-posframe (path leaf)
+  (let* ((wnd (cdr leaf))
+         (str (apply #'string path))
+         (bufname (format "*aw-posframe-buffer-%s*" (gensym))))
+    (with-selected-window wnd
+      (push bufname aw--posframe-frames)
+      (posframe-show bufname
+                     :string str
+                     :poshandler 'posframe-poshandler-window-center
+                     :font (face-font 'aw-leading-char-face)
+                     :foreground-color (face-foreground 'aw-leading-char-face)
+                     :background-color (face-background 'aw-leading-char-face)))))
+
+(defun aw--remove-leading-chars-posframe ()
+  (map nil #'posframe-delete aw--posframe-frames))
+
+(defun ace-window-posframe-enable ()
+  (setq aw--lead-overlay-fn #'aw--lead-overlay-posframe
+        aw--remove-leading-chars-fn #'aw--remove-leading-chars-posframe))
+
+(defun ace-window-posframe-disable ()
+  (setq aw--lead-overlay-fn #'aw--lead-overlay
+        aw--remove-leading-chars-fn #'aw--remove-leading))
+
+;;;###autoload
+(define-minor-mode ace-window-posframe-mode
+  ""
+  :global t
+  :require 'ace-window
+  :init-value nil
+  (if ace-window-posframe-mode
+      (ace-window-posframe-enable)
+    (ace-window-posframe-disable)))
+
+(provide 'ace-window-posframe)

--- a/ace-window-posframe.el
+++ b/ace-window-posframe.el
@@ -1,5 +1,7 @@
 (defvar aw--posframe-frames '())
 
+(defvar aw-posframe-position-handler #'posframe-poshandler-window-center)
+
 (defun aw--lead-overlay-posframe (path leaf)
   (let* ((wnd (cdr leaf))
          (str (apply #'string path))
@@ -8,7 +10,7 @@
       (push bufname aw--posframe-frames)
       (posframe-show bufname
                      :string str
-                     :poshandler 'posframe-poshandler-window-center
+                     :poshandler aw-posframe-position-handler
                      :font (face-font 'aw-leading-char-face)
                      :foreground-color (face-foreground 'aw-leading-char-face)
                      :background-color (face-background 'aw-leading-char-face)))))

--- a/ace-window.el
+++ b/ace-window.el
@@ -407,6 +407,15 @@ LEAF is (PT . WND)."
         (overlay-put ol 'window wnd)
         (push ol avy--overlays-lead)))))
 
+(defvar aw--lead-overlay-fn #'aw--lead-overlay
+  "Function used to display the lead chars.")
+
+(defun aw--remove-leading-chars ()
+  (avy--remove-leading-chars))
+
+(defvar aw--remove-leading-chars-fn #'aw--remove-leading-chars
+  "Function used to cleanup lead chars.")
+
 (defun aw--make-backgrounds (wnd-list)
   "Create a dim background overlay for each window on WND-LIST."
   (when aw-background
@@ -571,8 +580,8 @@ Amend MODE-LINE to the mode line for the duration of the selection."
                                               (if (and ace-window-display-mode
                                                        (null aw-display-mode-overlay))
                                                   (lambda (_path _leaf))
-                                                #'aw--lead-overlay)
-                                              #'avy--remove-leading-chars)))
+                                                aw--lead-overlay-fn)
+                                              aw--remove-leading-chars-fn)))
                           (if (eq res 'exit)
                               (setq aw-action nil)
                             (or (cdr res)


### PR DESCRIPTION
Use posframes for overlays.

There does seem to be a slight but noticable delay when displaying the posframes. Haven't investigated too much into why.