### PR TITLE
Do not quote symbols inside defcustom `:type` spec.

### DIFF
--- a/ace-window.el
+++ b/ace-window.el
@@ -117,8 +117,8 @@ Use M-0 `ace-window' to toggle this value."
 (defcustom aw-leading-char-style 'char
   "Style of the leading char overlay."
   :type '(choice
-          (const :tag "single char" 'char)
-          (const :tag "full path" 'path)))
+          (const :tag "single char" char)
+          (const :tag "full path" path)))
 
 (defcustom aw-dispatch-always nil
   "When non-nil, `ace-window' will issue a `read-char' even for one window.
@@ -150,8 +150,8 @@ Its value is a (width . height) pair in pixels or nil for the default frame size
   "Window positions of the character overlay.
 Consider changing this if the overlay tends to overlap with other things."
   :type '(choice
-          (const :tag "top left corner only" 'top-left)
-          (const :tag "both left corners" 'left)))
+          (const :tag "top left corner only" top-left)
+          (const :tag "both left corners" left)))
 
 ;; Must be defined before `aw-make-frame-char' since its :set function references this.
 (defvar aw-dispatch-alist


### PR DESCRIPTION
If the `:type` spec of a `defcustom` is complex, it is quoted and therefore symbols inside it do not have to be quoted themselves. If they are, the Customize buffer will display a `(mismatch)` error.