### PR TITLE
Improve the leading char faces in posframe.

### DIFF
--- a/ace-window-posframe.el
+++ b/ace-window-posframe.el
@@ -28,11 +28,8 @@
     (with-selected-window wnd
       (push bufname aw--posframe-frames)
       (posframe-show bufname
-                     :string str
-                     :poshandler aw-posframe-position-handler
-                     :font (face-font 'aw-leading-char-face)
-                     :foreground-color (face-foreground 'aw-leading-char-face nil t)
-                     :background-color (face-background 'aw-leading-char-face nil t)))))
+                     :string (propertize str 'face 'aw-leading-char-face)
+                     :poshandler aw-posframe-position-handler))))
 
 (defun aw--remove-leading-chars-posframe ()
   ;; Hide rather than delete. See aw--lead-overlay-posframe for why.


### PR DESCRIPTION
It's not reliable with :font keyword in posframe.
e.g. '((t (:inherit 'font-lock-keyword-face :height 4.0)). After a while the height was changed to 1.0 somehow.

It's clean and simple to display the propertized leading chars. And it should have better performance.