### PR TITLE
Use "call-interactively" when executing a command in a window

### DIFF
--- a/ace-window.el
+++ b/ace-window.el
@@ -870,7 +870,7 @@ Modify `aw-fair-aspect-ratio' to tweak behavior."
   "Execute a command in WINDOW."
   (aw-switch-to-window window)
   (unwind-protect
-      (funcall
+      (call-interactively
        (key-binding
         (read-key-sequence
          "Enter key sequence: ")))


### PR DESCRIPTION
This PR makes "aw-execute-command-other-window" work for all commands.

Currently, we use funcall; and this fails for some commands and as an example:

```
ELISP> (funcall 'find-file)
*** Eval error ***  Wrong number of arguments: #[(ad--addoit-function filename &optional wildcards) "\306\307 \310\216\311\312
\"\211\205\0\313\314
\"\205\0\315\313\314
\"!\203)\0\313\316
\"\202*\0

\"\203<\0eb\210Sy\210-)\207" [ad-return-value save-match-data-internal filename matched line-number ad--addoit-function nil match-data #[nil "\301\302\"\207" [save-match-data-internal set-match-data evaporate] 3] string-match "^\\(.*\\):\\([0-9]+\\):?$" match-string 2 string-to-number 1 wildcards] 5], 1
```
And this is fixed by:

```
(call-interactively 'find-file)
```
This should fix this [issue](https://github.com/abo-abo/ace-window/issues/220)