### PR TITLE
Remove unnecessary cl-case quotes

### DIFF
--- a/ace-window.el
+++ b/ace-window.el
@@ -537,9 +537,9 @@ Amend MODE-LINE to the mode line for the duration of the selection."
   (setq aw-action action)
   (let ((start-window (selected-window))
         (next-window-scope (cl-case aw-scope
-                             ('visible 'visible)
-                             ('global 'visible)
-                             ('frame 'frame)))
+                             (visible 'visible)
+                             (global 'visible)
+                             (frame 'frame)))
         (wnd-list (aw-window-list))
         window)
     (setq window


### PR DESCRIPTION
Emacs master is now warning when you incorrectly include quotes in cl-case forms.  Loading ace-window currently yields:

```
ace-window.el: Warning: Case 'visible will match ‘quote’.  If that’s intended, write (visible quote) instead.  Otherwise, don’t quote ‘visible’.
ace-window.el: Warning: Case 'global will match ‘quote’.  If that’s intended, write (global quote) instead.  Otherwise, don’t quote ‘global’.
ace-window.el: Warning: Case 'frame will match ‘quote’.  If that’s intended, write (frame quote) instead.  Otherwise, don’t quote ‘frame’.
```

I believe this PR will fix those errors.

Thank you for all your software, including ace-window. :)